### PR TITLE
Renamed duplicate flow IDs, remove keypad battery from Opener

### DIFF
--- a/app.json
+++ b/app.json
@@ -198,12 +198,12 @@
         ]
       },
       {
-        "id": "nuki_state_changed",
+        "id": "nuki_opener_state_changed",
         "title": {
-          "en": "Nuki state changed",
-          "nl": "Nuki status gewijzigd",
-          "de": "Nuki Status hat sich geändert",
-          "it": "Lo stato Nuki è cambiato"
+          "en": "Nuki Opener state changed",
+          "nl": "Nuki Opener status gewijzigd",
+          "de": "Nuki Opener Status hat sich geändert",
+          "it": "Lo stato Nuki Opener è cambiato"
         },
         "hint": {
           "en": "State and/or continuous mode have changed. The tags \"State\" and \"Continuous mode\" contain the updated values. The local tags \"Previous state\" and \"Previous continuous mode\" contain previous values.",
@@ -336,48 +336,6 @@
             "filter": "driver_id=opener"
           }
         ]
-      },
-      {
-        "id": "alarm_battery_keypad_true",
-        "title": {
-          "en": "The Keypad battery alarm turned on",
-          "nl": "De Keypad batterijwaarschuwing gaat aan",
-          "de": "Der Keypadbatterie-Alarm ist angegangen",
-          "fr": "L'alarme batterie Keypad s'est activée",
-          "it": "L'allarme della batteria Keypad è stato attivato",
-          "es": "La alarma de la batería Keypad se ha activado"
-        },
-        "filter": {
-          "capabilities": "alarm_battery_keypad"
-        },
-        "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=opener"
-          }
-        ]
-      },
-      {
-        "id": "alarm_battery_keypad_false",
-        "title": {
-          "en": "The Keypad battery alarm turned off",
-          "nl": "De Keypad batterijwaarschuwing gaat uit",
-          "de": "Der Keypadbatterie-Alarm ist ausgegangen",
-          "fr": "L'alarme batterie Keypad s'est désactivée",
-          "it": "L'allarme della batteria Keypad è stato disattivato",
-          "es": "La alarma de la batería Keypad se ha desactivado"
-        },
-        "filter": {
-          "capabilities": "alarm_battery_keypad"
-        },
-        "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=opener"
-          }
-        ]
       }
     ],
     "conditions": [
@@ -488,27 +446,6 @@
               "de": "Sekunden",
               "it": "Secondi"
             }
-          }
-        ]
-      },
-      {
-        "id": "alarm_battery_keypad",
-        "title": {
-          "en": "The Keypad battery alarm is !{{on|off}}",
-          "nl": "De Keypad batterijwaarschuwing is !{{aan|uit}}",
-          "de": "Der Keypadbatterie-Alarm ist !{{an|aus}}",
-          "fr": "L'alarme batterie Keypad est !{{en marche|arrêtée}}",
-          "it": "L'allarme della batteria Keypad è !{{acceso|spento}}",
-          "es": "La alarma de la batería Keypad está !{{activada|desactivada}}"
-        },
-        "filter": {
-          "capabilities": "alarm_battery_keypad"
-        },
-        "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=opener"
           }
         ]
       }

--- a/drivers/opener/device.js
+++ b/drivers/opener/device.js
@@ -52,7 +52,7 @@ class OpenerDevice extends NukiDevice {
             this.log('Already locked. No action needed');
             return Promise.resolve();
           }
-          
+
           this.progressingAction = QUICK_ACTION_LOCK;
           // It seems that, even if result.success is false, the action is
           //  performed correctly by Nuki. For that resons the "result" object
@@ -140,9 +140,9 @@ class OpenerDevice extends NukiDevice {
             this.setCapabilityValue('nuki_state', openingStr);
             this.setCapabilityValue('openerstate', openingStr);
             this.setCapabilityValue('locked', false);
-            flow.getDeviceTriggerCard('nuki_state_changed').trigger(this, prevArg, {});
+            flow.getDeviceTriggerCard('nuki_opener_state_changed').trigger(this, prevArg, {});
             flow.getDeviceTriggerCard('openerstateChanged').trigger(this, { openerstate: openingStr }, {});
-            // Safety timer that can automatically restore the current status 
+            // Safety timer that can automatically restore the current status
             //  after a while, if the event from Opener is missed.
             this._openingTimer = setTimeout(() => this._restoreStatusBeforeOpening(prevArg.previous_state), 16000);
             return Promise.resolve();
@@ -359,9 +359,9 @@ class OpenerDevice extends NukiDevice {
             this.setCapabilityValue('nuki_state', openingStr);
             this.setCapabilityValue('openerstate', openingStr);
             this.setCapabilityValue('locked', false);
-            flow.getDeviceTriggerCard('nuki_state_changed').trigger(this, prevArg, {});
+            flow.getDeviceTriggerCard('nuki_opener_state_changed').trigger(this, prevArg, {});
             flow.getDeviceTriggerCard('openerstateChanged').trigger(this, { openerstate: openingStr }, {});
-            // Safety timer that can automatically restore the current status 
+            // Safety timer that can automatically restore the current status
             //  after a while, if the event from Opener is missed.
             this._openingTimer = setTimeout(() => this._restoreStatusBeforeOpening(prevArg.previous_state), 16000);
             await this.progressingActionDone();
@@ -508,7 +508,7 @@ class OpenerDevice extends NukiDevice {
       }
       this.setCapabilityValue('nuki_state', nukiState);
       // Trigger nuki_state_changed.
-      flow.getDeviceTriggerCard('nuki_state_changed').trigger(this, { previous_state: prevState, previous_continuous_mode: prevContinuousMode }, {});
+      flow.getDeviceTriggerCard('nuki_opener_state_changed').trigger(this, { previous_state: prevState, previous_continuous_mode: prevContinuousMode }, {});
     }
     // Update capability locked
     if (locked != this.getCapabilityValue('locked')) {
@@ -563,7 +563,7 @@ class OpenerDevice extends NukiDevice {
     // Update capability nuki_state and trigger nuki_state_changed flow card.
     const nukiState = (continuousMode ? this.homey.__('device.continuous_mode') : baseState);
     this.setCapabilityValue('nuki_state', nukiState);
-    flow.getDeviceTriggerCard('nuki_state_changed').trigger(this, {
+    flow.getDeviceTriggerCard('nuki_opener_state_changed').trigger(this, {
       previous_state: this.homey.__('device.opening'),
       previous_continuous_mode: continuousMode
     }, {});

--- a/drivers/opener/driver.flow.compose.json
+++ b/drivers/opener/driver.flow.compose.json
@@ -1,12 +1,12 @@
 {
   "triggers": [
     {
-      "id": "nuki_state_changed",
+      "id": "nuki_opener_state_changed",
       "title": {
-        "en": "Nuki state changed",
-        "nl": "Nuki status gewijzigd",
-        "de": "Nuki Status hat sich geändert",
-        "it": "Lo stato Nuki \u00E8 cambiato"
+        "en": "Nuki Opener state changed",
+        "nl": "Nuki Opener status gewijzigd",
+        "de": "Nuki Opener Status hat sich geändert",
+        "it": "Lo stato Nuki Opener \u00E8 cambiato"
       },
       "hint": {
         "en": "State and/or continuous mode have changed. The tags \"State\" and \"Continuous mode\" contain the updated values. The local tags \"Previous state\" and \"Previous continuous mode\" contain previous values.",
@@ -109,12 +109,6 @@
         "it": "Il campanello ha suonato"
       },
       "args": []
-    },
-    {
-      "$extends": "alarm_battery_keypad_true"
-    },
-    {
-      "$extends": "alarm_battery_keypad_false"
     }
   ],
   "conditions": [
@@ -160,9 +154,6 @@
           }
         }
       ]
-    },
-    {
-      "$extends": "alarm_battery_keypad"
     }
   ],
   "actions": [


### PR DESCRIPTION
This fixes the "Found multiple Flow card triggers with the id "alarm_battery_keypad_true"" issue and some follow-up issues. Works for me at least (installed, not tested).